### PR TITLE
Added linter along with rules

### DIFF
--- a/project/frontend/careerPath-UI/.eslintrc.js
+++ b/project/frontend/careerPath-UI/.eslintrc.js
@@ -1,0 +1,39 @@
+module.exports = {
+    parser: '@typescript-eslint/parser',
+    plugins: ['@typescript-eslint'],
+    extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+    rules: {
+      'indent': ['error', 2],
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/no-unused-vars': ['error', { 'argsIgnorePattern': '^_' }],
+      'import/order': ['error', {
+        'groups': [['builtin', 'external'], 'internal', ['parent', 'sibling', 'index']],
+        'newlines-between': 'always'
+      }]
+    }
+  };
+  
+
+
+//  Indentation Rule:
+
+// 'indent': ['error', 2]
+// This rule enforces consistent indentation of code blocks. It's set to an error level (meaning violations will be reported), and it enforces an indentation of 2 spaces.
+
+
+// Explicit Function Return Type Rule:
+
+// '@typescript-eslint/explicit-function-return-type': 'off'
+// This rule is turned off. It would normally enforce explicit return types on functions in TypeScript. However, in this configuration, it's disabled to avoid requiring explicit return types.
+
+
+// Unused Variables Rule:
+
+// '@typescript-eslint/no-unused-vars': ['error', { 'argsIgnorePattern': '^_' }]
+// This rule reports unused variables in TypeScript code. It's set to an error level. The configuration allows variables whose names start with an underscore (_) to be ignored when checking for unused variables.
+
+
+// Import Order Rule:
+
+// 'import/order': ['error', { ... }]
+// This rule enforces a consistent order for import statements. The specific configuration provided enforces the order of imports based on different groups (builtin, external, internal, parent/sibling/index) and requires newlines between groups.

--- a/project/frontend/careerPath-UI/lint-report.txt
+++ b/project/frontend/careerPath-UI/lint-report.txt
@@ -1,0 +1,484 @@
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\.eslintrc.js
+   1:1  error  Definition for rule 'import/order' was not found  import/order
+   1:1  error  'module' is not defined                           no-undef
+   2:1  error  Expected indentation of 2 spaces but found 4      indent
+   3:1  error  Expected indentation of 2 spaces but found 4      indent
+   4:1  error  Expected indentation of 2 spaces but found 4      indent
+   5:1  error  Expected indentation of 2 spaces but found 4      indent
+   6:1  error  Expected indentation of 4 spaces but found 6      indent
+   7:1  error  Expected indentation of 4 spaces but found 6      indent
+   8:1  error  Expected indentation of 4 spaces but found 6      indent
+   9:1  error  Expected indentation of 4 spaces but found 6      indent
+  10:1  error  Expected indentation of 6 spaces but found 8      indent
+  11:1  error  Expected indentation of 6 spaces but found 8      indent
+  12:1  error  Expected indentation of 4 spaces but found 6      indent
+  13:1  error  Expected indentation of 2 spaces but found 4      indent
+  14:1  error  Expected indentation of 0 spaces but found 2      indent
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\admin-dashboard\admin-dashboard.component.spec.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\admin-dashboard\admin-dashboard.component.ts
+   1:1   error  Definition for rule 'import/order' was not found                            import/order
+  24:14  error  Unexpected any. Specify a different type                                    @typescript-eslint/no-explicit-any
+  43:1   error  Expected indentation of 8 spaces but found 6                                indent
+  44:1   error  Expected indentation of 8 spaces but found 6                                indent
+  45:1   error  Expected indentation of 6 spaces but found 4                                indent
+  49:21  error  Unexpected any. Specify a different type                                    @typescript-eslint/no-explicit-any
+  51:9   error  'foundObject' is never reassigned. Use 'const' instead                      prefer-const
+  57:25  error  Unexpected any. Specify a different type                                    @typescript-eslint/no-explicit-any
+  60:13  error  'response' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars
+  67:1   error  Expected indentation of 8 spaces but found 6                                indent
+  68:1   error  Expected indentation of 8 spaces but found 6                                indent
+  69:1   error  Expected indentation of 10 spaces but found 8                               indent
+  70:1   error  Expected indentation of 8 spaces but found 6                                indent
+  71:1   error  Expected indentation of 8 spaces but found 6                                indent
+  72:1   error  Expected indentation of 6 spaces but found 4                                indent
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\app-routing.module.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\app.component.spec.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\app.component.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\app.module.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\card\card.component.spec.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\card\card.component.ts
+   1:1  error  Definition for rule 'import/order' was not found  import/order
+  34:1  error  Expected indentation of 6 spaces but found 8      indent
+  35:1  error  Expected indentation of 4 spaces but found 6      indent
+  36:1  error  Expected indentation of 4 spaces but found 6      indent
+  37:1  error  Expected indentation of 6 spaces but found 8      indent
+  38:1  error  Expected indentation of 4 spaces but found 6      indent
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\constants\constant.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\dashboard\dashboard.component.spec.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\dashboard\dashboard.component.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\employer-dashboard\employer-dashboard.component.spec.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\employer-dashboard\employer-dashboard.component.ts
+   1:1   error  Definition for rule 'import/order' was not found                            import/order
+  41:1   error  Expected indentation of 8 spaces but found 6                                indent
+  42:1   error  Expected indentation of 8 spaces but found 6                                indent
+  43:1   error  Expected indentation of 6 spaces but found 4                                indent
+  47:22  error  Unexpected any. Specify a different type                                    @typescript-eslint/no-explicit-any
+  53:19  error  Unexpected any. Specify a different type                                    @typescript-eslint/no-explicit-any
+  59:1   error  Expected indentation of 8 spaces but found 12                               indent
+  59:19  error  'response' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars
+  60:1   error  Expected indentation of 10 spaces but found 14                              indent
+  61:1   error  Expected indentation of 10 spaces but found 14                              indent
+  62:1   error  Expected indentation of 12 spaces but found 16                              indent
+  63:1   error  Expected indentation of 10 spaces but found 14                              indent
+  64:1   error  Expected indentation of 10 spaces but found 14                              indent
+  65:1   error  Expected indentation of 8 spaces but found 12                               indent
+  66:1   error  Expected indentation of 10 spaces but found 12                              indent
+  67:1   error  Expected indentation of 10 spaces but found 12                              indent
+  68:1   error  Expected indentation of 10 spaces but found 12                              indent
+  69:1   error  Expected indentation of 12 spaces but found 14                              indent
+  70:1   error  Expected indentation of 10 spaces but found 12                              indent
+  71:1   error  Expected indentation of 8 spaces but found 10                               indent
+  72:1   error  Expected indentation of 6 spaces but found 10                               indent
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\footer\footer.component.spec.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\footer\footer.component.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\header\header.component.spec.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\header\header.component.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\job-posting-detail\job-posting-detail.component.spec.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\job-posting-detail\job-posting-detail.component.ts
+    1:1   error  Definition for rule 'import/order' was not found                            import/order
+   39:30  error  Unexpected any. Specify a different type                                    @typescript-eslint/no-explicit-any
+   57:9   error  'data' is never reassigned. Use 'const' instead                             prefer-const
+   66:31  error  Unexpected any. Specify a different type                                    @typescript-eslint/no-explicit-any
+   78:9   error  'data' is never reassigned. Use 'const' instead                             prefer-const
+   84:13  error  'response' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars
+   91:1   error  Expected indentation of 8 spaces but found 6                                indent
+   92:1   error  Expected indentation of 8 spaces but found 6                                indent
+   93:1   error  Expected indentation of 8 spaces but found 6                                indent
+   94:1   error  Expected indentation of 10 spaces but found 8                               indent
+   95:1   error  Expected indentation of 8 spaces but found 6                                indent
+   96:1   error  Expected indentation of 6 spaces but found 4                                indent
+  106:19  error  Unexpected any. Specify a different type                                    @typescript-eslint/no-explicit-any
+  107:9   error  'data' is never reassigned. Use 'const' instead                             prefer-const
+  113:1   error  Expected indentation of 10 spaces but found 12                              indent
+  114:1   error  Expected indentation of 12 spaces but found 14                              indent
+  115:1   error  Expected indentation of 12 spaces but found 14                              indent
+  116:1   error  Expected indentation of 10 spaces but found 12                              indent
+  117:1   error  Expected indentation of 10 spaces but found 12                              indent
+  118:1   error  Expected indentation of 12 spaces but found 14                              indent
+  119:1   error  Expected indentation of 12 spaces but found 14                              indent
+  120:1   error  Expected indentation of 10 spaces but found 12                              indent
+  121:1   error  Expected indentation of 10 spaces but found 12                              indent
+  122:1   error  Expected indentation of 12 spaces but found 14                              indent
+  123:1   error  Expected indentation of 12 spaces but found 14                              indent
+  124:1   error  Expected indentation of 10 spaces but found 12                              indent
+  132:1   error  Expected indentation of 8 spaces but found 6                                indent
+  133:1   error  Expected indentation of 8 spaces but found 6                                indent
+  134:1   error  Expected indentation of 6 spaces but found 4                                indent
+  138:25  error  Unexpected any. Specify a different type                                    @typescript-eslint/no-explicit-any
+  151:9   error  'body' is never reassigned. Use 'const' instead                             prefer-const
+  158:13  error  'response' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars
+  165:1   error  Expected indentation of 8 spaces but found 6                                indent
+  166:1   error  Expected indentation of 8 spaces but found 6                                indent
+  167:1   error  Expected indentation of 8 spaces but found 6                                indent
+  168:1   error  Expected indentation of 10 spaces but found 8                               indent
+  169:1   error  Expected indentation of 8 spaces but found 6                                indent
+  170:1   error  Expected indentation of 6 spaces but found 4                                indent
+  174:25  error  Unexpected any. Specify a different type                                    @typescript-eslint/no-explicit-any
+  185:9   error  'body' is never reassigned. Use 'const' instead                             prefer-const
+  192:13  error  'response' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars
+  199:1   error  Expected indentation of 8 spaces but found 6                                indent
+  200:1   error  Expected indentation of 8 spaces but found 6                                indent
+  201:1   error  Expected indentation of 8 spaces but found 6                                indent
+  202:1   error  Expected indentation of 10 spaces but found 8                               indent
+  203:1   error  Expected indentation of 8 spaces but found 6                                indent
+  204:1   error  Expected indentation of 6 spaces but found 4                                indent
+  208:25  error  Unexpected any. Specify a different type                                    @typescript-eslint/no-explicit-any
+  210:9   error  'foundObject' is never reassigned. Use 'const' instead                      prefer-const
+  225:1   error  Expected indentation of 8 spaces but found 6                                indent
+  226:1   error  Expected indentation of 8 spaces but found 6                                indent
+  227:1   error  Expected indentation of 8 spaces but found 6                                indent
+  228:1   error  Expected indentation of 10 spaces but found 8                               indent
+  228:13  error  'student' is never reassigned. Use 'const' instead                          prefer-const
+  229:1   error  Expected indentation of 10 spaces but found 8                               indent
+  230:1   error  Expected indentation of 10 spaces but found 8                               indent
+  231:1   error  Expected indentation of 10 spaces but found 8                               indent
+  232:1   error  Expected indentation of 10 spaces but found 8                               indent
+  233:1   error  Expected indentation of 8 spaces but found 6                                indent
+  236:1   error  Expected indentation of 8 spaces but found 6                                indent
+  237:1   error  Expected indentation of 8 spaces but found 6                                indent
+  238:1   error  Expected indentation of 6 spaces but found 4                                indent
+  249:1   error  Expected indentation of 8 spaces but found 6                                indent
+  250:1   error  Expected indentation of 8 spaces but found 6                                indent
+  251:1   error  Expected indentation of 6 spaces but found 4                                indent
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\job-status\job-status.component.spec.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\job-status\job-status.component.ts
+   1:1   error  Definition for rule 'import/order' was not found  import/order
+   9:18  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  14:27  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\login\login.component.spec.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\login\login.component.ts
+   1:1  error  Definition for rule 'import/order' was not found  import/order
+  20:1  error  Expected indentation of 4 spaces but found 6      indent
+  21:1  error  Expected indentation of 6 spaces but found 8      indent
+  22:1  error  Expected indentation of 6 spaces but found 8      indent
+  23:1  error  Expected indentation of 4 spaces but found 6      indent
+  24:1  error  Expected indentation of 2 spaces but found 4      indent
+  36:1  error  Expected indentation of 6 spaces but found 4      indent
+  37:1  error  Expected indentation of 8 spaces but found 6      indent
+  38:1  error  Expected indentation of 10 spaces but found 8     indent
+  39:1  error  Expected indentation of 10 spaces but found 8     indent
+  40:1  error  Expected indentation of 10 spaces but found 8     indent
+  41:1  error  Expected indentation of 10 spaces but found 8     indent
+  42:1  error  Expected indentation of 8 spaces but found 6      indent
+  43:1  error  Expected indentation of 10 spaces but found 6     indent
+  44:1  error  Expected indentation of 10 spaces but found 6     indent
+  45:1  error  Expected indentation of 10 spaces but found 6     indent
+  46:1  error  Expected indentation of 12 spaces but found 8     indent
+  47:1  error  Expected indentation of 10 spaces but found 6     indent
+  48:1  error  Expected indentation of 8 spaces but found 4      indent
+  49:1  error  Expected indentation of 6 spaces but found 4      indent
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\new-job-posting\new-job-posting.component.spec.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\new-job-posting\new-job-posting.component.ts
+   1:1   error  Definition for rule 'import/order' was not found                            import/order
+  35:9   error  'data' is never reassigned. Use 'const' instead                             prefer-const
+  43:1   error  Expected indentation of 6 spaces but found 4                                indent
+  44:1   error  Expected indentation of 8 spaces but found 6                                indent
+  44:13  error  'response' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars
+  45:1   error  Expected indentation of 10 spaces but found 8                               indent
+  46:1   error  Expected indentation of 10 spaces but found 8                               indent
+  51:1   error  Expected indentation of 8 spaces but found 6                                indent
+  52:1   error  Expected indentation of 10 spaces but found 6                               indent
+  53:1   error  Expected indentation of 10 spaces but found 6                               indent
+  54:1   error  Expected indentation of 10 spaces but found 6                               indent
+  55:1   error  Expected indentation of 12 spaces but found 8                               indent
+  56:1   error  Expected indentation of 10 spaces but found 6                               indent
+  57:1   error  Expected indentation of 8 spaces but found 4                                indent
+  58:1   error  Expected indentation of 6 spaces but found 4                                indent
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\pipe\search.pipe.spec.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\pipe\search.pipe.ts
+  1:1   error  Definition for rule 'import/order' was not found  import/order
+  7:20  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  7:48  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\pipe\time-ago.pipe.spec.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\pipe\time-ago.pipe.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\query-sidebar\query-sidebar.component.spec.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\query-sidebar\query-sidebar.component.ts
+   1:1   error  Definition for rule 'import/order' was not found                            import/order
+  27:14  error  Unexpected any. Specify a different type                                    @typescript-eslint/no-explicit-any
+  35:1   error  Expected indentation of 8 spaces but found 6                                indent
+  36:1   error  Expected indentation of 6 spaces but found 4                                indent
+  41:9   error  'data' is never reassigned. Use 'const' instead                             prefer-const
+  46:13  error  'response' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars
+  52:1   error  Expected indentation of 8 spaces but found 6                                indent
+  53:1   error  Expected indentation of 6 spaces but found 4                                indent
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\search.pipe.spec.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\services\employer\employer.service.spec.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\services\employer\employer.service.ts
+   1:1   error  Definition for rule 'import/order' was not found  import/order
+  13:19  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  15:39  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  21:24  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  21:41  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  27:25  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  27:42  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  31:22  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  39:48  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  39:65  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  42:48  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  42:65  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  46:48  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  50:47  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\services\login\login.service.spec.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\services\login\login.service.ts
+   1:1   error  Definition for rule 'import/order' was not found  import/order
+  23:23  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  23:40  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  29:24  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  29:41  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\services\student\student.service.spec.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\services\student\student.service.ts
+   1:1   error  Definition for rule 'import/order' was not found  import/order
+  17:42  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  29:32  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  34:24  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  34:41  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  40:21  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  52:39  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  52:56  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\services\user\user.service.spec.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\services\user\user.service.ts
+   1:1   error  Definition for rule 'import/order' was not found  import/order
+  22:13  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  28:26  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  51:29  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  57:29  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  61:38  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  65:22  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  65:39  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  69:27  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  69:44  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  73:19  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  73:36  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\signup\signup.component.spec.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\signup\signup.component.ts
+   1:1   error  Definition for rule 'import/order' was not found                            import/order
+  20:1   error  Expected indentation of 4 spaces but found 6                                indent
+  21:1   error  Expected indentation of 6 spaces but found 8                                indent
+  22:1   error  Expected indentation of 6 spaces but found 8                                indent
+  23:1   error  Expected indentation of 6 spaces but found 8                                indent
+  24:1   error  Expected indentation of 6 spaces but found 8                                indent
+  25:1   error  Expected indentation of 6 spaces but found 8                                indent
+  26:1   error  Expected indentation of 4 spaces but found 6                                indent
+  27:1   error  Expected indentation of 2 spaces but found 4                                indent
+  38:1   error  Expected indentation of 6 spaces but found 4                                indent
+  39:1   error  Expected indentation of 8 spaces but found 6                                indent
+  39:13  error  'response' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars
+  40:1   error  Expected indentation of 10 spaces but found 8                               indent
+  41:1   error  Expected indentation of 10 spaces but found 8                               indent
+  42:1   error  Expected indentation of 12 spaces but found 10                              indent
+  43:1   error  Expected indentation of 10 spaces but found 8                               indent
+  44:1   error  Expected indentation of 10 spaces but found 8                               indent
+  45:1   error  Expected indentation of 8 spaces but found 6                                indent
+  46:1   error  Expected indentation of 10 spaces but found 6                               indent
+  47:1   error  Expected indentation of 10 spaces but found 6                               indent
+  48:1   error  Expected indentation of 10 spaces but found 6                               indent
+  49:1   error  Expected indentation of 12 spaces but found 8                               indent
+  50:1   error  Expected indentation of 10 spaces but found 6                               indent
+  51:1   error  Expected indentation of 8 spaces but found 4                                indent
+  52:1   error  Expected indentation of 6 spaces but found 4                                indent
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\student-dashboard\student-dashboard.component.spec.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\student-dashboard\student-dashboard.component.ts
+   1:1   error  Definition for rule 'import/order' was not found  import/order
+  35:14  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  36:19  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  54:1   error  Expected indentation of 8 spaces but found 6      indent
+  55:1   error  Expected indentation of 8 spaces but found 6      indent
+  56:1   error  Expected indentation of 6 spaces but found 4      indent
+  60:22  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  70:19  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+  71:9   error  'data' is never reassigned. Use 'const' instead   prefer-const
+  75:1   error  Expected indentation of 12 spaces but found 14    indent
+  76:1   error  Expected indentation of 12 spaces but found 14    indent
+  82:1   error  Expected indentation of 8 spaces but found 6      indent
+  83:1   error  Expected indentation of 6 spaces but found 4      indent
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\upload\upload.component.spec.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\upload\upload.component.ts
+   1:1   error  Definition for rule 'import/order' was not found                            import/order
+  21:25  error  Unexpected any. Specify a different type                                    @typescript-eslint/no-explicit-any
+  38:15  error  'response' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars
+  44:1   error  Expected indentation of 10 spaces but found 8                               indent
+  45:1   error  Expected indentation of 10 spaces but found 8                               indent
+  46:1   error  Expected indentation of 12 spaces but found 10                              indent
+  47:1   error  Expected indentation of 10 spaces but found 8                               indent
+  49:1   error  Expected indentation of 8 spaces but found 6                                indent
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\user-detail\user-detail.component.spec.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\user-detail\user-detail.component.ts
+   1:1   error  Definition for rule 'import/order' was not found  import/order
+  28:13  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\user-list\user-list.component.spec.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\user-list\user-list.component.ts
+   1:1   error  Definition for rule 'import/order' was not found                            import/order
+  19:13  error  Unexpected any. Specify a different type                                    @typescript-eslint/no-explicit-any
+  30:1   error  Expected indentation of 8 spaces but found 6                                indent
+  31:1   error  Expected indentation of 8 spaces but found 6                                indent
+  32:1   error  Expected indentation of 6 spaces but found 4                                indent
+  36:25  error  Unexpected any. Specify a different type                                    @typescript-eslint/no-explicit-any
+  38:9   error  'foundObject' is never reassigned. Use 'const' instead                      prefer-const
+  45:25  error  Unexpected any. Specify a different type                                    @typescript-eslint/no-explicit-any
+  48:13  error  'response' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars
+  56:1   error  Expected indentation of 8 spaces but found 6                                indent
+  57:1   error  Expected indentation of 8 spaces but found 6                                indent
+  58:1   error  Expected indentation of 6 spaces but found 4                                indent
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\user-profile\user-profile.component.spec.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\app\user-profile\user-profile.component.ts
+   1:1   error  Definition for rule 'import/order' was not found          import/order
+  12:1   error  Expected indentation of 2 spaces but found 0              indent
+  13:1   error  Expected indentation of 2 spaces but found 0              indent
+  14:1   error  Expected indentation of 2 spaces but found 0              indent
+  15:1   error  Expected indentation of 2 spaces but found 0              indent
+  16:1   error  Expected indentation of 2 spaces but found 0              indent
+  17:1   error  Expected indentation of 2 spaces but found 0              indent
+  19:1   error  Expected indentation of 2 spaces but found 0              indent
+  21:1   error  Expected indentation of 2 spaces but found 0              indent
+  21:9   error  Unexpected any. Specify a different type                  @typescript-eslint/no-explicit-any
+  23:1   error  Expected indentation of 2 spaces but found 0              indent
+  25:1   error  Expected indentation of 2 spaces but found 0              indent
+  26:1   error  Expected indentation of 4 spaces but found 2              indent
+  27:1   error  Expected indentation of 4 spaces but found 2              indent
+  28:1   error  Expected indentation of 4 spaces but found 2              indent
+  29:1   error  Expected indentation of 6 spaces but found 4              indent
+  29:24  error  Unexpected any. Specify a different type                  @typescript-eslint/no-explicit-any
+  30:1   error  Expected indentation of 6 spaces but found 4              indent
+  30:5   error  'candidateData' is never reassigned. Use 'const' instead  prefer-const
+  31:1   error  Expected indentation of 6 spaces but found 4              indent
+  32:1   error  Expected indentation of 6 spaces but found 4              indent
+  33:1   error  Expected indentation of 6 spaces but found 4              indent
+  34:1   error  Expected indentation of 6 spaces but found 4              indent
+  36:1   error  Expected indentation of 4 spaces but found 2              indent
+  37:1   error  Expected indentation of 4 spaces but found 2              indent
+  38:1   error  Expected indentation of 6 spaces but found 4              indent
+  39:1   error  Expected indentation of 4 spaces but found 2              indent
+  40:1   error  Expected indentation of 2 spaces but found 0              indent
+  42:1   error  Expected indentation of 2 spaces but found 0              indent
+  45:1   error  Expected indentation of 2 spaces but found 0              indent
+  47:1   error  Expected indentation of 2 spaces but found 0              indent
+  48:1   error  Expected indentation of 4 spaces but found 2              indent
+  49:1   error  Expected indentation of 4 spaces but found 2              indent
+  50:1   error  Expected indentation of 4 spaces but found 2              indent
+  51:1   error  Expected indentation of 4 spaces but found 2              indent
+  52:1   error  Expected indentation of 2 spaces but found 0              indent
+  54:1   error  Expected indentation of 2 spaces but found 0              indent
+  55:1   error  Expected indentation of 4 spaces but found 2              indent
+  56:1   error  Expected indentation of 4 spaces but found 2              indent
+  57:1   error  Expected indentation of 6 spaces but found 2              indent
+  58:1   error  Expected indentation of 8 spaces but found 4              indent
+  59:1   error  Expected indentation of 10 spaces but found 6             indent
+  60:1   error  Expected indentation of 10 spaces but found 6             indent
+  61:1   error  Expected indentation of 10 spaces but found 6             indent
+  62:1   error  Expected indentation of 10 spaces but found 6             indent
+  63:1   error  Expected indentation of 10 spaces but found 6             indent
+  64:1   error  Expected indentation of 10 spaces but found 6             indent
+  65:1   error  Expected indentation of 10 spaces but found 4             indent
+  67:1   error  Expected indentation of 10 spaces but found 6             indent
+  68:1   error  Expected indentation of 8 spaces but found 4              indent
+  69:1   error  Expected indentation of 10 spaces but found 4             indent
+  70:1   error  Expected indentation of 10 spaces but found 4             indent
+  71:1   error  Expected indentation of 8 spaces but found 2              indent
+  72:1   error  Expected indentation of 6 spaces but found 2              indent
+  73:1   error  Expected indentation of 2 spaces but found 0              indent
+  75:1   error  Expected indentation of 2 spaces but found 0              indent
+  75:25  error  Unexpected any. Specify a different type                  @typescript-eslint/no-explicit-any
+  76:1   error  Expected indentation of 4 spaces but found 2              indent
+  77:1   error  Expected indentation of 2 spaces but found 0              indent
+  79:1   error  Expected indentation of 2 spaces but found 0              indent
+  80:1   error  Expected indentation of 4 spaces but found 2              indent
+  81:1   error  Expected indentation of 6 spaces but found 4              indent
+  82:1   error  Expected indentation of 8 spaces but found 6              indent
+  83:1   error  Expected indentation of 6 spaces but found 4              indent
+  84:1   error  Expected indentation of 8 spaces but found 4              indent
+  85:1   error  Expected indentation of 6 spaces but found 2              indent
+  86:1   error  Expected indentation of 4 spaces but found 2              indent
+  87:1   error  Expected indentation of 2 spaces but found 0              indent
+
+C:\Users\laksh\Downloads\sep-project\CareerPaths-SOEN6011Summer2023\project\frontend\careerPath-UI\src\main.ts
+  1:1  error  Definition for rule 'import/order' was not found  import/order
+
+✖ 372 problems (372 errors, 0 warnings)
+  241 errors and 0 warnings potentially fixable with the `--fix` option.
+

--- a/project/frontend/careerPath-UI/package-lock.json
+++ b/project/frontend/careerPath-UI/package-lock.json
@@ -28,6 +28,9 @@
         "@angular/cli": "~16.1.4",
         "@angular/compiler-cli": "^16.1.0",
         "@types/jasmine": "~4.3.0",
+        "@typescript-eslint/eslint-plugin": "^6.3.0",
+        "@typescript-eslint/parser": "^6.3.0",
+        "eslint": "^8.46.0",
         "jasmine-core": "~4.6.0",
         "karma": "~6.4.0",
         "karma-chrome-launcher": "~3.2.0",
@@ -35,6 +38,15 @@
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.1.0",
         "typescript": "~5.1.3"
+      }
+    },
+    "node_modules/@aashutoshrathi/word-wrap": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2669,6 +2681,206 @@
         "node": ">=12"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
+      "integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.1.tgz",
+      "integrity": "sha512-9t7ZA7NGGK8ckelF0PQCfcxIUzs1Md5rrO6U/c+FIQNanea5UZC0wqKXH4vHBccmu4ZJgZ2idtPeW7+Q2npOEA==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "13.20.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.46.0.tgz",
+      "integrity": "sha512-a8TLtmPi8xzPkCbp/OGFUo5yhRkHM2Ko9kOWP4znJr0WAhWyThaw3PnwX4vOTWOAMsV2uRt32PPDcEz63esSaA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
+      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+      "dev": true,
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -4055,6 +4267,12 @@
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
     },
+    "node_modules/@types/semver": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+      "dev": true
+    },
     "node_modules/@types/send": {
       "version": "0.17.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.1.tgz",
@@ -4101,6 +4319,324 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.3.0.tgz",
+      "integrity": "sha512-IZYjYZ0ifGSLZbwMqIip/nOamFiWJ9AH+T/GYNZBWkVcyNQOFGtSMoWV7RvY4poYCMZ/4lHzNl796WOSNxmk8A==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.5.1",
+        "@typescript-eslint/scope-manager": "6.3.0",
+        "@typescript-eslint/type-utils": "6.3.0",
+        "@typescript-eslint/utils": "6.3.0",
+        "@typescript-eslint/visitor-keys": "6.3.0",
+        "debug": "^4.3.4",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.4",
+        "natural-compare": "^1.4.0",
+        "natural-compare-lite": "^1.4.0",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.3.0.tgz",
+      "integrity": "sha512-ibP+y2Gr6p0qsUkhs7InMdXrwldjxZw66wpcQq9/PzAroM45wdwyu81T+7RibNCh8oc0AgrsyCwJByncY0Ongg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "6.3.0",
+        "@typescript-eslint/types": "6.3.0",
+        "@typescript-eslint/typescript-estree": "6.3.0",
+        "@typescript-eslint/visitor-keys": "6.3.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.3.0.tgz",
+      "integrity": "sha512-WlNFgBEuGu74ahrXzgefiz/QlVb+qg8KDTpknKwR7hMH+lQygWyx0CQFoUmMn1zDkQjTBBIn75IxtWss77iBIQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.3.0",
+        "@typescript-eslint/visitor-keys": "6.3.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.3.0.tgz",
+      "integrity": "sha512-7Oj+1ox1T2Yc8PKpBvOKWhoI/4rWFd1j7FA/rPE0lbBPXTKjdbtC+7Ev0SeBjEKkIhKWVeZSP+mR7y1Db1CdfQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "6.3.0",
+        "@typescript-eslint/utils": "6.3.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.3.0.tgz",
+      "integrity": "sha512-K6TZOvfVyc7MO9j60MkRNWyFSf86IbOatTKGrpTQnzarDZPYPVy0oe3myTMq7VjhfsUAbNUW8I5s+2lZvtx1gg==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.3.0.tgz",
+      "integrity": "sha512-Xh4NVDaC4eYKY4O3QGPuQNp5NxBAlEvNQYOqJquR2MePNxO11E5K3t5x4M4Mx53IZvtpW+mBxIT0s274fLUocg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.3.0",
+        "@typescript-eslint/visitor-keys": "6.3.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.3.0.tgz",
+      "integrity": "sha512-hLLg3BZE07XHnpzglNBG8P/IXq/ZVXraEbgY7FM0Cnc1ehM8RMdn9mat3LubJ3KBeYXXPxV1nugWbQPjGeJk6Q==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.3.0",
+        "@typescript-eslint/types": "6.3.0",
+        "@typescript-eslint/typescript-estree": "6.3.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.3.0.tgz",
+      "integrity": "sha512-kEhRRj7HnvaSjux1J9+7dBen15CdWmDnwrpyiHsFX6Qx2iW5LOBUgNefOFeh2PjWPlNwN8TOn6+4eBU3J/gupw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.3.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@vitejs/plugin-basic-ssl": {
@@ -4325,6 +4861,15 @@
         "acorn": "^8"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/adjust-sourcemap-loader": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz",
@@ -4539,6 +5084,15 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
       "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
       "dev": true
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.14",
@@ -5623,6 +6177,12 @@
         }
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
+    },
     "node_modules/default-gateway": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
@@ -5721,6 +6281,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/dom-serialize": {
@@ -6032,6 +6604,60 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/eslint": {
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.46.0.tgz",
+      "integrity": "sha512-cIO74PvbW0qU8e0mIvk5IV3ToWdCq5FYG6gWPHHkx6gNdjlbAYvtfHmlCMXxjcoVaIdwy/IAt3+mDkZkfvb2Dg==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.1",
+        "@eslint/js": "^8.46.0",
+        "@humanwhocodes/config-array": "^0.11.10",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.2",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -6045,6 +6671,304 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz",
+      "integrity": "sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/globals": {
+      "version": "13.20.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -6056,6 +6980,27 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esquery/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/esrecurse": {
@@ -6348,6 +7293,12 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
+    },
     "node_modules/fastq": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -6382,6 +7333,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
       }
     },
     "node_modules/fill-range": {
@@ -6469,6 +7432,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "dev": true,
+      "dependencies": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
       }
     },
     "node_modules/flatted": {
@@ -6769,6 +7745,12 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
     "node_modules/handle-thing": {
@@ -7437,6 +8419,15 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-plain-obj": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
@@ -7753,6 +8744,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
     "node_modules/json5": {
@@ -8146,6 +9143,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/license-webpack-plugin": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/license-webpack-plugin/-/license-webpack-plugin-4.0.2.tgz",
@@ -8209,6 +9219,12 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
     "node_modules/log-symbols": {
@@ -8817,6 +9833,18 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
+    },
+    "node_modules/natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+      "dev": true
+    },
     "node_modules/needle": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/needle/-/needle-3.2.0.tgz",
@@ -9253,6 +10281,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+      "dev": true,
+      "dependencies": {
+        "@aashutoshrathi/word-wrap": "^1.2.3",
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/ora": {
@@ -9809,6 +10854,15 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
@@ -11136,6 +12190,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -11463,6 +12529,18 @@
         "tree-kill": "cli.js"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.1.tgz",
+      "integrity": "sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.13.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
@@ -11480,6 +12558,18 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/type-fest": {
@@ -12300,6 +13390,18 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zone.js": {

--- a/project/frontend/careerPath-UI/package.json
+++ b/project/frontend/careerPath-UI/package.json
@@ -6,7 +6,8 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test",
+    "lint": "eslint . --format stylish > lint-report.txt"
   },
   "private": true,
   "dependencies": {
@@ -30,6 +31,9 @@
     "@angular/cli": "~16.1.4",
     "@angular/compiler-cli": "^16.1.0",
     "@types/jasmine": "~4.3.0",
+    "@typescript-eslint/eslint-plugin": "^6.3.0",
+    "@typescript-eslint/parser": "^6.3.0",
+    "eslint": "^8.46.0",
     "jasmine-core": "~4.6.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",

--- a/project/frontend/careerPath-UI/src/app/new-job-posting/new-job-posting.component.ts
+++ b/project/frontend/careerPath-UI/src/app/new-job-posting/new-job-posting.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { EmployerService } from '../services/employer/employer.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-new-job-posting',
@@ -15,7 +16,8 @@ export class NewJobPostingComponent {
 
   constructor(private formBuilder: FormBuilder,
     private employeeService: EmployerService,
-    private snackBar: MatSnackBar){
+    private snackBar: MatSnackBar,
+    private router: Router){
     this.jobPostingForm = this.formBuilder.group({
       jobTitle: '',
       jobDesc: '',
@@ -47,6 +49,7 @@ export class NewJobPostingComponent {
           this.snackBar.open("Job Posting Successful!", 'Dismiss', {
             duration: 2000, // Set the duration (in milliseconds) for how long the snackbar will be displayed
           });
+          this.router.navigate(['/dashboard']);
         // }
       }, error: err => {
       // console.log(err);


### PR DESCRIPTION
Rules-


Indentation Rule:

'indent': ['error', 2]
This rule enforces consistent indentation of code blocks. It's set to an error level (meaning violations will be reported), and it enforces an indentation of 2 spaces.


Explicit Function Return Type Rule:

'@typescript-eslint/explicit-function-return-type': 'off'
This rule is turned off. It would normally enforce explicit return types on functions in TypeScript. However, in this configuration, it's disabled to avoid requiring explicit return types.


Unused Variables Rule:

'@typescript-eslint/no-unused-vars': ['error', { 'argsIgnorePattern': '^_' }]
This rule reports unused variables in TypeScript code. It's set to an error level. The configuration allows variables whose names start with an underscore (_) to be ignored when checking for unused variables.


Import Order Rule:

'import/order': ['error', { ... }]
This rule enforces a consistent order for import statements. The specific configuration provided enforces the order of imports based on different groups (builtin, external, internal, parent/sibling/index) and requires newlines between groups.